### PR TITLE
Tendermint v0.37 updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ tracing-subscriber = "0.2"
 doc = []
 
 [patch.crates-io]
-#tendermint = { path = "../tendermint-rs/tendermint" }
-#tendermint-proto = { path = "../tendermint-rs/proto" }
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
-tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+tendermint = { path = "../tendermint-rs/tendermint" }
+tendermint-proto = { path = "../tendermint-rs/proto" }
+#tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+#tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+#tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+#tendermint-proto = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.28.0"
-tendermint = "0.28.0"
 bytes = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"] }
@@ -23,17 +21,14 @@ futures = "0.3"
 tracing = "0.1"
 prost = "0.11"
 
+#tendermint-proto = "0.28.0"
+#tendermint = "0.28.0"
+tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+tendermint-proto = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+
 [dev-dependencies]
 structopt = "0.3"
 tracing-subscriber = "0.2"
 
 [features]
 doc = []
-
-[patch.crates-io]
-tendermint = { path = "../tendermint-rs/tendermint" }
-tendermint-proto = { path = "../tendermint-rs/proto" }
-#tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
-#tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
-#tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
-#tendermint-proto = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ documentation = "https://docs.rs/tower-abci"
 tendermint-proto = "0.28.0"
 tendermint = "0.28.0"
 bytes = "1"
-tokio = { version = "1", features = ["full"]}
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 tokio-stream = "0.1"
-tower = { version = "0.4", features = ["full"]}
+tower = { version = "0.4", features = ["full"] }
 pin-project = "1"
 futures = "0.3"
 tracing = "0.1"
@@ -30,3 +30,8 @@ tracing-subscriber = "0.2"
 [features]
 doc = []
 
+[patch.crates-io]
+#tendermint = { path = "../tendermint-rs/tendermint" }
+#tendermint-proto = { path = "../tendermint-rs/proto" }
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2,18 +2,7 @@ use std::marker::PhantomData;
 
 use tokio_util::codec::{Decoder, Encoder};
 
-use bytes::{Buf, BufMut, BytesMut};
-
-// encode_varint and decode_varint will be removed once
-// https://github.com/tendermint/tendermint/issues/5783 lands in Tendermint.
-pub fn encode_varint<B: BufMut>(val: u64, mut buf: &mut B) {
-    prost::encoding::encode_varint(val << 1, &mut buf);
-}
-
-pub fn decode_varint<B: Buf>(mut buf: &mut B) -> Result<u64, prost::DecodeError> {
-    let len = prost::encoding::decode_varint(&mut buf)?;
-    Ok(len >> 1)
-}
+use bytes::{BufMut, BytesMut};
 
 pub struct Decode<M> {
     state: DecodeState,
@@ -50,10 +39,10 @@ impl<M: prost::Message + Default> Decoder for Decode<M> {
                 // a sad hack, but it works.
                 // fix this
                 let mut tmp = src.clone().freeze();
-                let len = match decode_varint(&mut tmp) {
+                let len = match prost::encoding::decode_varint(&mut tmp) {
                     Ok(_) => {
                         // advance the real buffer
-                        decode_varint(src).unwrap() as usize
+                        prost::encoding::decode_varint(src).unwrap() as usize
                     }
                     Err(_) => {
                         tracing::trace!(?self.state, src.len = src.len(), "waiting for header data");
@@ -105,7 +94,7 @@ impl<M: prost::Message + Sized + std::fmt::Debug> Encoder<M> for Encode<M> {
         let mut buf = BytesMut::new();
         item.encode(&mut buf)?;
         let buf = buf.freeze();
-        encode_varint(buf.len() as u64, dst);
+        prost::encoding::encode_varint(buf.len() as u64, dst);
         dst.put(buf);
 
         Ok(())

--- a/src/split.rs
+++ b/src/split.rs
@@ -247,9 +247,10 @@ pub mod futures {
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             let this = self.project();
             match this.inner.poll(cx) {
-                Poll::Ready(rsp) => Poll::Ready(
-                    rsp.map(|rsp| rsp.try_into().expect("service gave wrong response type")),
-                ),
+                Poll::Ready(rsp) => Poll::Ready(rsp.map(|rsp| {
+                    rsp.try_into()
+                        .expect("consensus service gave wrong response type")
+                })),
                 Poll::Pending => Poll::Pending,
             }
         }
@@ -273,9 +274,10 @@ pub mod futures {
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             let this = self.project();
             match this.inner.poll(cx) {
-                Poll::Ready(rsp) => Poll::Ready(
-                    rsp.map(|rsp| rsp.try_into().expect("service gave wrong response type")),
-                ),
+                Poll::Ready(rsp) => Poll::Ready(rsp.map(|rsp| {
+                    rsp.try_into()
+                        .expect("mempool service gave wrong response type")
+                })),
                 Poll::Pending => Poll::Pending,
             }
         }
@@ -299,9 +301,10 @@ pub mod futures {
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             let this = self.project();
             match this.inner.poll(cx) {
-                Poll::Ready(rsp) => Poll::Ready(
-                    rsp.map(|rsp| rsp.try_into().expect("service gave wrong response type")),
-                ),
+                Poll::Ready(rsp) => Poll::Ready(rsp.map(|rsp| {
+                    rsp.try_into()
+                        .expect("info service gave wrong response type")
+                })),
                 Poll::Pending => Poll::Pending,
             }
         }
@@ -325,9 +328,10 @@ pub mod futures {
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             let this = self.project();
             match this.inner.poll(cx) {
-                Poll::Ready(rsp) => Poll::Ready(
-                    rsp.map(|rsp| rsp.try_into().expect("service gave wrong response type")),
-                ),
+                Poll::Ready(rsp) => Poll::Ready(rsp.map(|rsp| {
+                    rsp.try_into()
+                        .expect("snapshot service gave wrong response type")
+                })),
                 Poll::Pending => Poll::Pending,
             }
         }


### PR DESCRIPTION
The PR contains some updates that make the library work with the `v0.37-rc2` pre-release of Tendermint Core. 

It is built against a [draft PR](https://github.com/informalsystems/tendermint-rs/pull/1193) on `tendermint-rs` which has the necessary protobuf and domain types. That too needed some [small fixes](https://github.com/informalsystems/tendermint-rs/commit/011dc7bb427f43e14b245d15d7939b2bbffe9411), which I'm sure will be added shortly.

Unlike the `tendermint-rs` PR I'm not aiming here to support Tendermint v0.34 and and v0.37 at the same time. I don't know when/if the original `tower-abci` will be updated, and whether it will want to support both, or how it will be versioned. Since the changes are trivial and originated from the library authors in the first place, I don't plan to bother them with any upstreaming. Just wanted to get started with Tendermint v0.37; I expect we don't have to maintain this branch for long.


# Testing

I tested the changes using the `kvstore` examples. 

Get `tendermint`:

```shell
git clone https://github.com/tendermint/tendermint.git
cd tendermint
git checkout v0.37.0-rc2
make install
cd ..
```

Get `tendermint-rs`:

```shell
git clone git@github.com:aakoshh/tendermint-rs.git
cd tendermint-rs
git checkout origin/mikhail/multi-tc-version-support
cd -
```

Get `tower-abci`:

```shell
git clone git@github.com:consensus-shipyard/tower-abci.git
cd tower-abci
git checkout origin/tendermint-v0.37-updates
cd -
```

Run `kvstore`:

```shell
cd tower-abci
cargo run --example kvstore
```

Run `tendermint`:

```shell
tendermint init
tendermint unsafe-reset-all && tendermint start
```

See blocks being created:

```console
...
I[2023-01-12|12:57:14.707] Timed out                                    module=consensus dur=967.347513ms height=7 round=0 step=RoundStepNewHeight
I[2023-01-12|12:57:14.726] received proposal                            module=consensus proposal="Proposal{7/0 (817BFB7343F61DCA5DE1B5702D86996FAD4F9AD50768350ADD23C1E0429E0806:1:12B20DF45E66, -1) 4B1340369A42 @ 2023-01-12T12:57:14.719196643Z}"
I[2023-01-12|12:57:14.730] received complete proposal block             module=consensus height=7 hash=817BFB7343F61DCA5DE1B5702D86996FAD4F9AD50768350ADD23C1E0429E0806
I[2023-01-12|12:57:14.794] finalizing commit of block                   module=consensus height=7 hash=817BFB7343F61DCA5DE1B5702D86996FAD4F9AD50768350ADD23C1E0429E0806 root=0000000000000000 num_txs=0
I[2023-01-12|12:57:14.804] executed block                               module=state height=7 num_valid_txs=0 num_invalid_txs=0
I[2023-01-12|12:57:14.809] committed state                              module=state height=7 num_txs=0 app_hash=0000000000000000
I[2023-01-12|12:57:14.816] indexed block                                module=txindex height=7
...
```

Send a transaction:

```shell
curl -s 'localhost:26657/broadcast_tx_commit?tx="foo=bar"'
```

Send a query:

```shell
curl -s 'localhost:26657/abci_query?data="foo"' | jq -r ".result.response.value | @base64d"
```

All balls!


